### PR TITLE
Consider `.cu` and `.cuh` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Neovim plugin that can do sometings like VAssistX.
 use {
   'Kohirus/cppassist.nvim',
   opt = true,
-  ft = { "h", "cpp", "hpp", "c", "cc", "cxx" },
+  ft = { "h", "cpp", "hpp", "c", "cc", "cxx", "cuda" },
   config = function()
     require("cppassist").setup()
   end,

--- a/lua/cppassist/utils.lua
+++ b/lua/cppassist/utils.lua
@@ -104,10 +104,10 @@ function M.ExtensionCmd(extension)
 	else
 		local res = nil
 		local firstch = string.sub(extension, 1, 1)
-		if firstch == "h" then
-			res = " -e cpp -e cxx -e c -e cc "
-		elseif firstch == "c" then
-			res = " -e h -e hpp -e hxx "
+		if firstch == "h" or extension == "cuh" then
+			res = " -e cpp -e cxx -e c -e cc -e cu"
+		elseif firstch == "c" or extension == "cu" then
+			res = " -e h -e hpp -e hxx -e cuh"
 		else
 			print("Invalid filetype!")
 		end


### PR DESCRIPTION
Thank you for good plugin.

This small PR is to make the plugin work with CUDA source files.

CUDA is in C++, so the plugin logic works exactly the same for `hpp` and `cpp` files.

In short:

- `cuh` = `hpp`
- `cu` = `cpp`